### PR TITLE
Redesign/accounts page

### DIFF
--- a/qml/settings/Settings_Accounts.qml
+++ b/qml/settings/Settings_Accounts.qml
@@ -429,7 +429,7 @@ Page {
                                         var s = Utils.getLastSyncStatus(model.id);
                                         // Extract just the date/time part for brevity
                                         var interval = "";
-                                        if (model.sync_interval_minutes !== undefined && model.sync_interval_minutes !== null && model.sync_interval_minutes !== "") {
+                                        if (model.sync_interval_minutes !== undefined && model.sync_interval_minutes !== null && model.sync_interval_minutes !== "" && model.sync_interval_minutes !== 0) {
                                             interval = formatSyncInterval(model.sync_interval_minutes);
                                         } else {
                                             var gi = "15";

--- a/qml/settings/Settings_Accounts.qml
+++ b/qml/settings/Settings_Accounts.qml
@@ -546,8 +546,8 @@ Page {
 
                                         Icon {
                                             anchors.centerIn: parent
-                                            width: units.gu(2)
-                                            height: units.gu(2)
+                                            width: units.gu(2.2)
+                                            height: units.gu(2.2)
                                             name: "sync"
                                             color: "#ffffff"
                                         }
@@ -557,8 +557,8 @@ Page {
                                 // Custom checkbox for setting default (non-local only)
                                 Item {
                                     visible: model.id !== 0
-                                    width: units.gu(2.8)
-                                    height: units.gu(2.8)
+                                    width: units.gu(2.2)
+                                    height: units.gu(2.2)
                                     anchors.horizontalCenter: parent.horizontalCenter
 
                                     Rectangle {

--- a/qml/settings/Settings_Accounts.qml
+++ b/qml/settings/Settings_Accounts.qml
@@ -554,27 +554,16 @@ Page {
                                     }
                                 }
 
-                                // Star for setting default (non-local only)
-                                Item {
+                                // Checkbox for setting default (non-local only)
+                                CheckBox {
                                     visible: model.id !== 0
-                                    width: units.gu(4.5)
-                                    height: units.gu(2)
-
-                                    Icon {
-                                        anchors.centerIn: parent
-                                        width: units.gu(2)
-                                        height: units.gu(2)
-                                        name: model.is_default === 1 ? "starred" : "non-starred"
-                                        color: model.is_default === 1 ? LomiriColors.orange
-                                             : (theme.name === "Ubuntu.Components.Themes.SuruDark" ? "#555" : "#ccc")
-                                    }
-
-                                    MouseArea {
-                                        anchors.fill: parent
-                                        onClicked: {
-                                            if (model.is_default !== 1) {
-                                                setDefaultAccount(model.id);
-                                            }
+                                    anchors.horizontalCenter: parent.horizontalCenter
+                                    checked: model.is_default === 1
+                                    onClicked: {
+                                        if (model.is_default !== 1) {
+                                            setDefaultAccount(model.id);
+                                        } else {
+                                            checked = true; // prevent unchecking the default
                                         }
                                     }
                                 }

--- a/qml/settings/Settings_Accounts.qml
+++ b/qml/settings/Settings_Accounts.qml
@@ -554,16 +554,37 @@ Page {
                                     }
                                 }
 
-                                // Checkbox for setting default (non-local only)
-                                CheckBox {
+                                // Custom checkbox for setting default (non-local only)
+                                Item {
                                     visible: model.id !== 0
+                                    width: units.gu(2.8)
+                                    height: units.gu(2.8)
                                     anchors.horizontalCenter: parent.horizontalCenter
-                                    checked: model.is_default === 1
-                                    onClicked: {
-                                        if (model.is_default !== 1) {
-                                            setDefaultAccount(model.id);
-                                        } else {
-                                            checked = true; // prevent unchecking the default
+
+                                    Rectangle {
+                                        anchors.fill: parent
+                                        radius: units.gu(0.4)
+                                        color: model.is_default === 1 ? LomiriColors.orange : "transparent"
+                                        border.color: model.is_default === 1 ? LomiriColors.orange
+                                                    : (theme.name === "Ubuntu.Components.Themes.SuruDark" ? "#666" : "#aaa")
+                                        border.width: units.dp(2)
+
+                                        Icon {
+                                            anchors.centerIn: parent
+                                            width: units.gu(1.8)
+                                            height: units.gu(1.8)
+                                            name: "tick"
+                                            color: "#ffffff"
+                                            visible: model.is_default === 1
+                                        }
+                                    }
+
+                                    MouseArea {
+                                        anchors.fill: parent
+                                        onClicked: {
+                                            if (model.is_default !== 1) {
+                                                setDefaultAccount(model.id);
+                                            }
                                         }
                                     }
                                 }


### PR DESCRIPTION
This pull request significantly refactors and improves the account management UI in `Settings_Accounts.qml`. The changes modernize the visual layout, streamline account actions (edit, log, delete, sync), and enhance usability with clearer indicators and more compact information display. The update also introduces swipe actions for editing and deleting accounts, improves avatar and default account visualization, and combines sync status and interval into a concise line.

Key UI/UX improvements:

* Redesigned the account list layout for better clarity and compactness, including improved avatar display, a default account indicator, and a more readable text column for account details. [[1]](diffhunk://#diff-5fe1df32c8f2f27db67fcf00325bea57e1ceb99d669b3d2152a7ff69a54c9b62L262-R276) [[2]](diffhunk://#diff-5fe1df32c8f2f27db67fcf00325bea57e1ceb99d669b3d2152a7ff69a54c9b62L299-L458)
* Combined sync status and sync interval into a single, color-coded line for each account, making status information more accessible and visually distinct.

Account actions and interactivity:

* Replaced inline "Delete" and "Show Log" buttons with swipeable actions: swipe left to edit, swipe right for log and delete, following mobile UI conventions. [[1]](diffhunk://#diff-5fe1df32c8f2f27db67fcf00325bea57e1ceb99d669b3d2152a7ff69a54c9b62L283-L290) [[2]](diffhunk://#diff-5fe1df32c8f2f27db67fcf00325bea57e1ceb99d669b3d2152a7ff69a54c9b62L299-L458)
* Improved the sync button: now presented as a circular icon button with visual feedback, and sync status is managed more robustly, including error handling if background sync cannot be started. [[1]](diffhunk://#diff-5fe1df32c8f2f27db67fcf00325bea57e1ceb99d669b3d2152a7ff69a54c9b62L299-L458) [[2]](diffhunk://#diff-5fe1df32c8f2f27db67fcf00325bea57e1ceb99d669b3d2152a7ff69a54c9b62L468-R513)

Visual and theme adjustments:

* Updated background and highlight colors for better contrast and consistency with the SuruDark and light themes.
* Added spacing and alignment tweaks for a cleaner, more modern appearance. [[1]](diffhunk://#diff-5fe1df32c8f2f27db67fcf00325bea57e1ceb99d669b3d2152a7ff69a54c9b62L262-R276) [[2]](diffhunk://#diff-5fe1df32c8f2f27db67fcf00325bea57e1ceb99d669b3d2152a7ff69a54c9b62L299-L458)