### PR TITLE
Scroll issue

### DIFF
--- a/qml/components/richtext/RichTextEditor.qml
+++ b/qml/components/richtext/RichTextEditor.qml
@@ -71,6 +71,13 @@ Item {
     property bool _internalUpdate: false
 
     /**
+     * Tracks the last HTML content set to or received from Squire.
+     * Prevents the feedback loop where binding updates cause setText()
+     * to re-set identical content, which resets scroll position.
+     */
+    property string _lastSetContent: ""
+
+    /**
      * When true, suppress emitting the contentChanged signal.
      * Starts as true so Squire's very first init events (fired via the URL-hash
      * bridge during page load, before onLoadingChanged fires) cannot clobber
@@ -223,6 +230,12 @@ Item {
         var cleanedDoc = sanitizeHtml(htmlText ? htmlText.trim() : "");
         
         if (_isLoaded) {
+            // Skip if content is identical to what Squire already has,
+            // to avoid resetting scroll position via setHTML()
+            if (cleanedDoc === _lastSetContent) {
+                return;
+            }
+            _lastSetContent = cleanedDoc;
             // Suppress contentChanged during setHTML — Squire fires intermediate
             // empty-content events before delivering the real content.
             _suppressContentChanged = true;
@@ -489,6 +502,9 @@ Item {
                         // HTML including bridge/setup scripts
                         content = editor.stripScriptTags(content);
                         console.log("[RichTextEditor] contentChanged from Squire, length:", content.length);
+
+                        // Track what Squire currently has to prevent feedback loop
+                        editor._lastSetContent = content;
 
                         // Update internal text property always so editor.text stays
                         // in sync, but only emit the public contentChanged signal

--- a/qml/components/richtext/RichTextEditor.qml
+++ b/qml/components/richtext/RichTextEditor.qml
@@ -16,6 +16,7 @@
    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 import QtQuick 2.7
+import QtQuick.Window 2.2
 import Lomiri.Components 1.3
 import QtWebEngine 1.5
 import "js/html-sanitizer.js" as HtmlSanitizer
@@ -341,7 +342,11 @@ Item {
 
     WebEngineView {
         id: wv
-        anchors.fill: parent
+        anchors.top: parent.top
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.bottomMargin: editor._oskHeight
         zoomFactor: isMultiColumn ? 1.0 : 2.52
         backgroundColor: darkMode ? "#2d2d2d" : "#ffffff"
         
@@ -554,6 +559,37 @@ Item {
                 editor.currentHighlightColor = bgColorMatch[1];
             } else {
                 editor.currentHighlightColor = "transparent";
+            }
+        }
+    }
+
+    // ============ KEYBOARD HANDLING ============
+
+    /**
+     * On-screen keyboard height in QML coordinates.
+     * On Ubuntu Touch the OSK does not automatically resize WebEngineView,
+     * so we track Qt.inputMethod and shrink the web view ourselves.
+     */
+    property real _oskHeight: {
+        if (!Qt.inputMethod.visible) return 0;
+        // keyboardRectangle is in root-window (screen-logical) pixels;
+        // map to QML logical pixels by dividing by devicePixelRatio.
+        var kbRect = Qt.inputMethod.keyboardRectangle;
+        var ratio  = Screen.devicePixelRatio > 0 ? Screen.devicePixelRatio : 1;
+        return kbRect.height / ratio;
+    }
+
+    Connections {
+        target: Qt.inputMethod
+        onVisibleChanged: {
+            if (Qt.inputMethod.visible && _isLoaded && !readOnly) {
+                // After the WebEngineView shrinks, scroll the cursor into view
+                wv.runJavaScript("setTimeout(function(){ if(window.scrollCursorIntoView) window.scrollCursorIntoView(); }, 250);");
+            }
+        }
+        onKeyboardRectangleChanged: {
+            if (Qt.inputMethod.visible && _isLoaded && !readOnly) {
+                wv.runJavaScript("setTimeout(function(){ if(window.scrollCursorIntoView) window.scrollCursorIntoView(); }, 250);");
             }
         }
     }

--- a/qml/components/richtext/RichTextEditor.qml
+++ b/qml/components/richtext/RichTextEditor.qml
@@ -566,30 +566,32 @@ Item {
     // ============ KEYBOARD HANDLING ============
 
     /**
-     * On-screen keyboard height in QML coordinates.
-     * On Ubuntu Touch the OSK does not automatically resize WebEngineView,
-     * so we track Qt.inputMethod and shrink the web view ourselves.
+     * On-screen keyboard height (QML logical pixels).
+     * Qt.inputMethod.keyboardRectangle is in window coordinates,
+     * same coordinate space as QML — no devicePixelRatio conversion needed.
      */
-    property real _oskHeight: {
-        if (!Qt.inputMethod.visible) return 0;
-        // keyboardRectangle is in root-window (screen-logical) pixels;
-        // map to QML logical pixels by dividing by devicePixelRatio.
-        var kbRect = Qt.inputMethod.keyboardRectangle;
-        var ratio  = Screen.devicePixelRatio > 0 ? Screen.devicePixelRatio : 1;
-        return kbRect.height / ratio;
+    property real _oskHeight: Qt.inputMethod.visible
+                              ? Qt.inputMethod.keyboardRectangle.height
+                              : 0
+
+    /**
+     * Push the current keyboard height into the WebEngineView JS layer
+     * so scrollCursorIntoView() knows how much of the viewport is hidden.
+     * Heights are converted to CSS pixels (QML px / zoomFactor).
+     */
+    function _pushKeyboardHeightToJs() {
+        if (!_isLoaded) return;
+        var cssPx = Math.round(_oskHeight / wv.zoomFactor);
+        wv.runJavaScript("window.setKeyboardHeight(" + cssPx + ");");
     }
+
+    on_OskHeightChanged: _pushKeyboardHeightToJs()
 
     Connections {
         target: Qt.inputMethod
         onVisibleChanged: {
-            if (Qt.inputMethod.visible && _isLoaded && !readOnly) {
-                // After the WebEngineView shrinks, scroll the cursor into view
-                wv.runJavaScript("setTimeout(function(){ if(window.scrollCursorIntoView) window.scrollCursorIntoView(); }, 250);");
-            }
-        }
-        onKeyboardRectangleChanged: {
-            if (Qt.inputMethod.visible && _isLoaded && !readOnly) {
-                wv.runJavaScript("setTimeout(function(){ if(window.scrollCursorIntoView) window.scrollCursorIntoView(); }, 250);");
+            if (_isLoaded) {
+                editor._pushKeyboardHeightToJs();
             }
         }
     }

--- a/qml/components/richtext/js/editor.html
+++ b/qml/components/richtext/js/editor.html
@@ -209,10 +209,9 @@
                 console.log('[Editor] Squire editor found, setting up events');
 
                 // Scroll the cursor into the visible area.
-                // Called after input events and when the virtual keyboard
-                // resizes the viewport, so content behind the keyboard
-                // is scrolled up to remain visible.
-                function scrollCursorIntoView() {
+                // Exposed globally so QML can call it via runJavaScript
+                // when the on-screen keyboard appears or resizes.
+                window.scrollCursorIntoView = function() {
                     try {
                         var selection = window.getSelection();
                         if (!selection || selection.rangeCount === 0) return;
@@ -231,9 +230,7 @@
                         }
                         if (!rect) return;
 
-                        var viewportHeight = window.visualViewport
-                            ? window.visualViewport.height
-                            : window.innerHeight;
+                        var viewportHeight = window.innerHeight;
                         var margin = 40;
 
                         if (rect.bottom > viewportHeight - margin) {
@@ -244,7 +241,8 @@
                     } catch (e) {
                         // Best-effort; don't break editor on failure
                     }
-                }
+                };
+                var scrollCursorIntoView = window.scrollCursorIntoView;
 
                 // Track content changes
                 var lastContent = '';
@@ -267,12 +265,8 @@
                     }
                 });
 
-                // Detect virtual keyboard show/hide via viewport resize
-                if (window.visualViewport) {
-                    window.visualViewport.addEventListener('resize', function() {
-                        setTimeout(scrollCursorIntoView, 100);
-                    });
-                }
+                // Listen for window resize (e.g. QML resizing the WebEngineView
+                // when the on-screen keyboard appears)
                 window.addEventListener('resize', function() {
                     setTimeout(scrollCursorIntoView, 150);
                 });

--- a/qml/components/richtext/js/editor.html
+++ b/qml/components/richtext/js/editor.html
@@ -49,7 +49,7 @@
         }
 
         body {
-            height: 100%;
+            min-height: 100%;
             width: 100%;
             margin: 0;
             padding: 8px 12px;
@@ -87,6 +87,12 @@
 
         body:focus {
             outline: none;
+        }
+
+        /* When editable, add bottom padding so content can scroll
+           above the on-screen keyboard on mobile devices */
+        body[contenteditable="true"] {
+            padding-bottom: 45vh;
         }
 
         /* Selection styling */
@@ -208,6 +214,21 @@
 
                 console.log('[Editor] Squire editor found, setting up events');
 
+                // Keyboard height in CSS pixels, set from QML via
+                // window.setKeyboardHeight(). Used by scrollCursorIntoView
+                // to avoid scrolling behind the on-screen keyboard.
+                window._kbHeight = 0;
+
+                /**
+                 * Called from QML to inform JS about the on-screen keyboard
+                 * height in CSS pixels (already divided by zoomFactor).
+                 */
+                window.setKeyboardHeight = function(h) {
+                    window._kbHeight = h || 0;
+                    console.log('[Editor] Keyboard height set to', window._kbHeight, 'CSS px');
+                    scrollCursorIntoView();
+                };
+
                 // Scroll the cursor into the visible area.
                 // Exposed globally so QML can call it via runJavaScript
                 // when the on-screen keyboard appears or resizes.
@@ -230,11 +251,13 @@
                         }
                         if (!rect) return;
 
-                        var viewportHeight = window.innerHeight;
+                        // Visible height = viewport minus keyboard.
+                        // _kbHeight is set from QML; falls back to 0.
+                        var visibleHeight = window.innerHeight - (window._kbHeight || 0);
                         var margin = 40;
 
-                        if (rect.bottom > viewportHeight - margin) {
-                            document.body.scrollTop += (rect.bottom - viewportHeight + margin);
+                        if (rect.bottom > visibleHeight - margin) {
+                            document.body.scrollTop += (rect.bottom - visibleHeight + margin);
                         } else if (rect.top < margin) {
                             document.body.scrollTop += (rect.top - margin);
                         }

--- a/qml/components/richtext/js/editor.html
+++ b/qml/components/richtext/js/editor.html
@@ -208,6 +208,44 @@
 
                 console.log('[Editor] Squire editor found, setting up events');
 
+                // Scroll the cursor into the visible area.
+                // Called after input events and when the virtual keyboard
+                // resizes the viewport, so content behind the keyboard
+                // is scrolled up to remain visible.
+                function scrollCursorIntoView() {
+                    try {
+                        var selection = window.getSelection();
+                        if (!selection || selection.rangeCount === 0) return;
+
+                        var range = selection.getRangeAt(0);
+                        var rect = range.getBoundingClientRect();
+
+                        // Collapsed cursor may report zero-size rect; fall back
+                        // to the parent element's bounding box.
+                        if (!rect || (rect.height === 0 && rect.width === 0)) {
+                            var node = range.startContainer;
+                            if (node.nodeType === 3) node = node.parentElement;
+                            if (node && node.getBoundingClientRect) {
+                                rect = node.getBoundingClientRect();
+                            }
+                        }
+                        if (!rect) return;
+
+                        var viewportHeight = window.visualViewport
+                            ? window.visualViewport.height
+                            : window.innerHeight;
+                        var margin = 40;
+
+                        if (rect.bottom > viewportHeight - margin) {
+                            document.body.scrollTop += (rect.bottom - viewportHeight + margin);
+                        } else if (rect.top < margin) {
+                            document.body.scrollTop += (rect.top - margin);
+                        }
+                    } catch (e) {
+                        // Best-effort; don't break editor on failure
+                    }
+                }
+
                 // Track content changes
                 var lastContent = '';
                 
@@ -217,6 +255,26 @@
                         lastContent = content;
                         oxide.sendMessage('contentChanged', { content: content });
                     }
+                    // Keep cursor visible while typing (especially when
+                    // the on-screen keyboard is covering part of the view)
+                    scrollCursorIntoView();
+                });
+
+                // Also scroll cursor into view on Enter / new-line
+                document.body.addEventListener('keydown', function(e) {
+                    if (e.key === 'Enter' || e.keyCode === 13) {
+                        setTimeout(scrollCursorIntoView, 50);
+                    }
+                });
+
+                // Detect virtual keyboard show/hide via viewport resize
+                if (window.visualViewport) {
+                    window.visualViewport.addEventListener('resize', function() {
+                        setTimeout(scrollCursorIntoView, 100);
+                    });
+                }
+                window.addEventListener('resize', function() {
+                    setTimeout(scrollCursorIntoView, 150);
                 });
 
                 // Track path changes (formatting state)

--- a/qml/components/richtext/js/squire-qtwebengine-bridge.js
+++ b/qml/components/richtext/js/squire-qtwebengine-bridge.js
@@ -48,9 +48,11 @@
                 var encoded = encodeURIComponent(JSON.stringify(message));
                 window.location.hash = '#qtevent:' + type + ':' + encoded;
 
+                // Clear hash without scrolling to top — history.replaceState
+                // removes the fragment without triggering scroll behavior
                 setTimeout(function () {
                     if (window.location.hash.indexOf('#qtevent:' + type) === 0) {
-                        window.location.hash = '';
+                        history.replaceState(null, null, window.location.pathname + window.location.search);
                     }
                 }, 10);
             } catch (e) {
@@ -127,9 +129,10 @@
                 var encoded = encodeURIComponent(JSON.stringify(reply));
                 window.location.hash = '#qtreply:' + callId + ':' + encoded;
 
+                // Clear hash without scrolling to top
                 setTimeout(function () {
                     if (window.location.hash.indexOf('#qtreply:' + callId) === 0) {
-                        window.location.hash = '';
+                        history.replaceState(null, null, window.location.pathname + window.location.search);
                     }
                 }, 10);
             } catch (e) {


### PR DESCRIPTION
This pull request improves the mobile and touch experience in the `RichTextEditor` by addressing issues with on-screen keyboard handling, cursor visibility, and scroll position preservation. The changes ensure that the editor properly adjusts its layout and scrolls the cursor into view when the on-screen keyboard is shown, and also prevents unnecessary resets of the scroll position when updating content. Additionally, the communication bridge between QML and the embedded web editor is improved to avoid unwanted scrolling.

**Mobile & Keyboard Handling Improvements:**

* Added logic in `RichTextEditor.qml` to track the on-screen keyboard height (`_oskHeight`) and adjust the `WebEngineView`'s bottom margin accordingly. This height is pushed to the JS editor so that it can avoid scrolling content behind the keyboard. [[1]](diffhunk://#diff-decd8e1c30a34b7bc0959b2c4486c5587048d9126c5e59c48e1b397a6b1006daL331-R349) [[2]](diffhunk://#diff-decd8e1c30a34b7bc0959b2c4486c5587048d9126c5e59c48e1b397a6b1006daR566-R598)
* In `editor.html`, introduced a global `window.setKeyboardHeight` function and logic to keep the cursor visible above the keyboard by dynamically scrolling the editor content as needed. The body now has extra bottom padding when editable to allow scrolling above the keyboard. [[1]](diffhunk://#diff-47cb38df16facc96d9a6178b1e9b6d9f6fe095afb691bf71bc9a66d120f1b62fR92-R97) [[2]](diffhunk://#diff-47cb38df16facc96d9a6178b1e9b6d9f6fe095afb691bf71bc9a66d120f1b62fR217-R269) [[3]](diffhunk://#diff-47cb38df16facc96d9a6178b1e9b6d9f6fe095afb691bf71bc9a66d120f1b62fR279-R294)

**Scroll Position & Content Update Fixes:**

* Added a `_lastSetContent` property in `RichTextEditor.qml` to prevent unnecessary content updates that would reset the scroll position, avoiding feedback loops between QML and the JS editor. [[1]](diffhunk://#diff-decd8e1c30a34b7bc0959b2c4486c5587048d9126c5e59c48e1b397a6b1006daR74-R80) [[2]](diffhunk://#diff-decd8e1c30a34b7bc0959b2c4486c5587048d9126c5e59c48e1b397a6b1006daR234-R239) [[3]](diffhunk://#diff-decd8e1c30a34b7bc0959b2c4486c5587048d9126c5e59c48e1b397a6b1006daR511-R513)

**WebEngineView & Layout Tweaks:**

* Changed `WebEngineView` anchoring to use explicit margins for better control, especially when the keyboard is visible.
* Updated CSS in `editor.html` to use `min-height: 100%` for the body, improving scroll behavior.

**QML-JS Bridge Enhancements:**

* Modified the hash-clearing mechanism in `squire-qtwebengine-bridge.js` to use `history.replaceState` instead of resetting the hash, preventing the browser from scrolling to the top after QML-JS communication. [[1]](diffhunk://#diff-2db6cbb8ffdb4232fcaafa54176d435168c42e0b6104c223ac30e17e58e58002R51-R55) [[2]](diffhunk://#diff-2db6cbb8ffdb4232fcaafa54176d435168c42e0b6104c223ac30e17e58e58002R132-R135)