### PR TITLE
Email/assignee filter

### DIFF
--- a/models/accounts.js
+++ b/models/accounts.js
@@ -158,7 +158,7 @@ function getUsers(accountId) {
 
         db.transaction(function (tx) {
             var result = tx.executeSql(
-                        "SELECT u.id, u.name, u.odoo_record_id, u.account_id, a.name as account_name FROM res_users_app u LEFT JOIN users a ON u.account_id = a.id WHERE u.account_id = ?",
+                        "SELECT u.id, u.name, COALESCE(NULLIF(u.login, ''), NULLIF(u.email, ''), NULLIF(u.work_email, ''), '') as email, u.odoo_record_id, u.account_id, a.name as account_name FROM res_users_app u LEFT JOIN users a ON u.account_id = a.id WHERE u.account_id = ?",
                         [accountId]
                         );
 

--- a/models/activity.js
+++ b/models/activity.js
@@ -1939,7 +1939,7 @@ function getAllActivityAssignees(accountId) {
                     var placeholders = userIds.map(function () { return '?'; }).join(',');
 
                     var userQuery = `
-                        SELECT u.id, u.odoo_record_id, u.name, u.account_id, a.name as account_name
+                        SELECT u.id, u.odoo_record_id, u.name, COALESCE(NULLIF(u.login, ''), NULLIF(u.email, ''), NULLIF(u.work_email, ''), '') as email, u.account_id, a.name as account_name
                         FROM res_users_app u
                         LEFT JOIN users a ON u.account_id = a.id
                         WHERE u.account_id = ? AND u.odoo_record_id IN (${placeholders})
@@ -1956,6 +1956,7 @@ function getAllActivityAssignees(accountId) {
                             id: userRow.id,
                             odoo_record_id: userRow.odoo_record_id,
                             name: userRow.name,
+                            email: userRow.email || "",
                             account_id: userRow.account_id,
                             account_name: userRow.account_name || "Unknown Account"
                         });

--- a/models/task.js
+++ b/models/task.js
@@ -3193,7 +3193,7 @@ function getAllTaskAssignees(accountId) {
                     var placeholders = userIds.map(function () { return '?'; }).join(',');
 
                     var userQuery = `
-                        SELECT u.id, u.odoo_record_id, u.name, u.account_id, a.name as account_name
+                        SELECT u.id, u.odoo_record_id, u.name, COALESCE(NULLIF(u.login, ''), NULLIF(u.email, ''), NULLIF(u.work_email, ''), '') as email, u.account_id, a.name as account_name
                         FROM res_users_app u
                         LEFT JOIN users a ON u.account_id = a.id
                         WHERE u.account_id = ? AND u.odoo_record_id IN (${placeholders})
@@ -3210,6 +3210,7 @@ function getAllTaskAssignees(accountId) {
                             id: userRow.id,
                             odoo_record_id: userRow.odoo_record_id,
                             name: userRow.name,
+                            email: userRow.email || "",
                             account_id: userRow.account_id,
                             account_name: userRow.account_name || "Unknown Account"
                         });

--- a/qml/Activity_Page.qml
+++ b/qml/Activity_Page.qml
@@ -391,6 +391,7 @@ Page {
                             id: id,
                             odoo_record_id: id,
                             name: assignee.name,
+                            email: assignee.email || "",
                             account_name: assignee.account_name || "",
                             account_id: projectAccountId
                         });
@@ -398,6 +399,7 @@ Page {
                 }
 
                 availableAssignees = filteredAssignees;
+                assigneeFilterMenu.showAccountName = false;
                 assigneeFilterMenu.assigneeModel = availableAssignees;
             } else if (filterByAccount && currentAccountId >= 0) {
                 // Use the same method as MultiAssigneeSelector for specific account
@@ -414,6 +416,7 @@ Page {
                             id: id,
                             odoo_record_id: id,
                             name: assignee.name,
+                            email: assignee.email || "",
                             account_name: assignee.account_name || "",
                             account_id: currentAccountId
                         });
@@ -421,10 +424,12 @@ Page {
                 }
 
                 availableAssignees = filteredAssignees;
+                assigneeFilterMenu.showAccountName = false;
                 assigneeFilterMenu.assigneeModel = availableAssignees;
             } else {
                 // For "All Accounts" (-1), load assignees from all accounts that have activities
                 availableAssignees = Activity.getAllActivityAssignees(-1); // -1 means all accounts
+                assigneeFilterMenu.showAccountName = true;
                 assigneeFilterMenu.assigneeModel = availableAssignees;
             }
         } catch (e) {

--- a/qml/Task_Page.qml
+++ b/qml/Task_Page.qml
@@ -139,6 +139,7 @@ Page {
                             id: id,
                             odoo_record_id: id,
                             name: assignee.name,
+                            email: assignee.email || "",
                             account_name: assignee.account_name || "",
                             account_id: projectAccountId
                         });
@@ -146,6 +147,7 @@ Page {
                 }
 
                 availableAssignees = filteredAssignees;
+                assigneeFilterMenu.showAccountName = false;
                 assigneeFilterMenu.assigneeModel = availableAssignees;
             } else if (currentAccountId >= 0) {
                 // Use the same method as MultiAssigneeSelector for specific account
@@ -162,6 +164,7 @@ Page {
                             id: id,
                             odoo_record_id: id,
                             name: assignee.name,
+                            email: assignee.email || "",
                             account_name: assignee.account_name || "",
                             account_id: currentAccountId
                         });
@@ -169,11 +172,13 @@ Page {
                 }
 
                 availableAssignees = filteredAssignees;
+                assigneeFilterMenu.showAccountName = false;
                 assigneeFilterMenu.assigneeModel = availableAssignees;
             } else {
                 // For "All Accounts" (-1), load assignees from all accounts that have tasks
 
                 availableAssignees = Task.getAllTaskAssignees(-1); // -1 means all accounts
+                assigneeFilterMenu.showAccountName = true;
                 assigneeFilterMenu.assigneeModel = availableAssignees;
             }
         } catch (e) {

--- a/qml/components/AssigneeFilterMenu.qml
+++ b/qml/components/AssigneeFilterMenu.qml
@@ -238,6 +238,7 @@ Item {
                     function update() {
                         clear();
                         var searchText = searchField.text.toLowerCase();
+                        var filteredAssignees = [];
 
                         for (var i = 0; i < assigneeModel.length; i++) {
                             var assignee = assigneeModel[i];
@@ -246,17 +247,40 @@ Item {
                                 displayText = assignee.name + " (" + assignee.account_name + ")";
                             }
                             var emailText = assignee.email || "";
+                            var assigneeId = assignee.odoo_record_id || assignee.id;
+                            var accountId = assignee.account_id || -1;
+                            var isSelected = isAssigneeSelected(assigneeId, accountId);
+
                             if (!searchText || displayText.toLowerCase().indexOf(searchText) >= 0 || emailText.toLowerCase().indexOf(searchText) >= 0) {
-                                append({
-                                    "assigneeId": assignee.odoo_record_id || assignee.id,
+                                filteredAssignees.push({
+                                    "assigneeId": assigneeId,
                                     "name": assignee.name,
                                     "email": emailText,
                                     "account_name": assignee.account_name || "",
-                                    "account_id": assignee.account_id || -1,
+                                    "account_id": accountId,
                                     "displayText": displayText,
-                                    "selected": isAssigneeSelected(assignee.odoo_record_id || assignee.id, assignee.account_id || -1)
+                                    "selected": isSelected,
+                                    "sectionLabel": isSelected ? "selected" : "others"
                                 });
                             }
+                        }
+
+                        filteredAssignees.sort(function (a, b) {
+                            if (a.selected !== b.selected) {
+                                return a.selected ? -1 : 1;
+                            }
+
+                            var nameA = (a.name || "").toLowerCase();
+                            var nameB = (b.name || "").toLowerCase();
+                            if (nameA < nameB)
+                                return -1;
+                            if (nameA > nameB)
+                                return 1;
+                            return 0;
+                        });
+
+                        for (var j = 0; j < filteredAssignees.length; j++) {
+                            append(filteredAssignees[j]);
                         }
                     }
                 }
@@ -264,6 +288,32 @@ Item {
                 ScrollBar.vertical: ScrollBar {
                     policy: ScrollBar.AsNeeded
                     width: units.gu(1)
+                }
+
+                section.property: "sectionLabel"
+                section.criteria: ViewSection.FullString
+                section.delegate: Item {
+                    width: assigneeListView.width
+                    height: units.gu(2.2)
+
+                    Rectangle {
+                        anchors.left: parent.left
+                        anchors.right: parent.right
+                        anchors.top: parent.top
+                        height: 1
+                        color: theme.palette.normal.base
+                        opacity: 0.45
+                    }
+
+                    Text {
+                        anchors.left: parent.left
+                        anchors.leftMargin: units.gu(1)
+                        anchors.verticalCenter: parent.verticalCenter
+                        text: section === "selected" ? i18n.dtr("ubtms", "Selected") : i18n.dtr("ubtms", "Others")
+                        font.pixelSize: units.gu(1.35)
+                        color: theme.palette.normal.backgroundSecondaryText
+                        opacity: 0.75
+                    }
                 }
 
                 delegate: Rectangle {
@@ -365,9 +415,6 @@ Item {
 
                             // Trigger property change notification
                             selectedAssigneeIds = selectedAssigneeIds.slice();
-
-                            // Update model
-                            filterModel.setProperty(index, "selected", checkbox.checked);
                         }
                     }
 
@@ -485,12 +532,8 @@ Item {
     // Update filter model when selectedAssigneeIds changes
     onSelectedAssigneeIdsChanged: {
         if (filterModel) {
-            // Update the selected state in the model using composite ID matching
-            for (var i = 0; i < filterModel.count; i++) {
-                var item = filterModel.get(i);
-                var isSelected = isAssigneeSelected(item.assigneeId, item.account_id);
-                filterModel.setProperty(i, "selected", isSelected);
-            }
+            // Rebuild and sort so selected entries stay pinned at the top.
+            filterModel.update();
         }
     }
 

--- a/qml/components/AssigneeFilterMenu.qml
+++ b/qml/components/AssigneeFilterMenu.qml
@@ -248,7 +248,7 @@ Item {
                             }
                             var emailText = assignee.email || "";
                             var assigneeId = assignee.odoo_record_id || assignee.id;
-                            var accountId = assignee.account_id || -1;
+                            var accountId = (assignee.account_id === undefined || assignee.account_id === null) ? -1 : assignee.account_id;
                             var isSelected = isAssigneeSelected(assigneeId, accountId);
 
                             if (!searchText || displayText.toLowerCase().indexOf(searchText) >= 0 || emailText.toLowerCase().indexOf(searchText) >= 0) {

--- a/qml/components/AssigneeFilterMenu.qml
+++ b/qml/components/AssigneeFilterMenu.qml
@@ -39,6 +39,7 @@ Item {
     property var assigneeModel: []
     property bool expanded: false
     property var selectedAssigneeIds: []
+    property bool showAccountName: false
     property int maxMenuHeight: units.gu(50)
 
     // Helper function to check if an assignee is selected (handles both old and new format)
@@ -244,10 +245,12 @@ Item {
                             if (assignee.account_name) {
                                 displayText = assignee.name + " (" + assignee.account_name + ")";
                             }
-                            if (!searchText || displayText.toLowerCase().indexOf(searchText) >= 0) {
+                            var emailText = assignee.email || "";
+                            if (!searchText || displayText.toLowerCase().indexOf(searchText) >= 0 || emailText.toLowerCase().indexOf(searchText) >= 0) {
                                 append({
                                     "assigneeId": assignee.odoo_record_id || assignee.id,
                                     "name": assignee.name,
+                                    "email": emailText,
                                     "account_name": assignee.account_name || "",
                                     "account_id": assignee.account_id || -1,
                                     "displayText": displayText,
@@ -291,14 +294,14 @@ Item {
                             color: theme.palette.normal.backgroundText
                         }
 
-                        // Assignee name with account
+                        // Assignee name with email
                         Column {
                             anchors.verticalCenter: parent.verticalCenter
                             width: parent.width - checkbox.width - units.gu(6)
                             spacing: units.gu(0.2)
 
                             Text {
-                                text: model.name
+                                text: (showAccountName && model.account_name !== "") ? model.name + " (" + model.account_name + ")" : model.name
                                 font.pixelSize: units.gu(2)
                                 color: theme.palette.normal.backgroundText
                                 elide: Text.ElideRight
@@ -306,8 +309,8 @@ Item {
                             }
 
                             Text {
-                                visible: model.account_name !== ""
-                                text: "(" + model.account_name + ")"
+                                visible: model.email !== ""
+                                text: model.email
                                 font.pixelSize: units.gu(1.5)
                                 color: theme.palette.normal.backgroundSecondaryText
                                 elide: Text.ElideRight


### PR DESCRIPTION
This pull request enhances the handling and display of user assignee information across both the backend (JavaScript models) and frontend (QML components). The main improvements include consistently retrieving and displaying user email addresses, improving assignee filtering and sorting, and making the assignee selection UI clearer and more informative.

**Backend: User Data Retrieval**

- All relevant user queries in `models/accounts.js`, `models/activity.js`, and `models/task.js` now return an `email` field for each user, prioritizing `login`, then `email`, then `work_email`, and defaulting to an empty string if none are present. This ensures a consistent and reliable email field for downstream usage. [[1]](diffhunk://#diff-b1ecf65ba963c97fb40a075e2200c035a341efbbc64402623540735d6e68f89dL161-R161) [[2]](diffhunk://#diff-ffedca43b6e03ad1c9c991575e672db67ea2f79e8720d7d92b2608858dd78261L1942-R1942) [[3]](diffhunk://#diff-4070379afe3dae54403330c28ec70f941eda2456cb6443b3609f1ed99e811629L3196-R3196)
- The user objects returned by activity and task assignee queries now explicitly include the `email` property, defaulting to an empty string if missing. [[1]](diffhunk://#diff-ffedca43b6e03ad1c9c991575e672db67ea2f79e8720d7d92b2608858dd78261R1959) [[2]](diffhunk://#diff-4070379afe3dae54403330c28ec70f941eda2456cb6443b3609f1ed99e811629R3213)

**Frontend: QML Assignee Handling and UI**

- The assignee objects in both `Activity_Page.qml` and `Task_Page.qml` now include the `email` field, ensuring that email addresses are available for display and filtering in the UI. [[1]](diffhunk://#diff-8c38d9ab4d2ca727ab5a84e4f188915973c4f6c5c71586d7ba0c991f1fb5b29fR394-R402) [[2]](diffhunk://#diff-8c38d9ab4d2ca727ab5a84e4f188915973c4f6c5c71586d7ba0c991f1fb5b29fR419-R432) [[3]](diffhunk://#diff-9ef01b287429d2039b4a877f22f248182da9f8e785077496d939f8b2d9b633c2R142-R150) [[4]](diffhunk://#diff-9ef01b287429d2039b4a877f22f248182da9f8e785077496d939f8b2d9b633c2R167-R181)
- The `AssigneeFilterMenu.qml` component has been updated to:
  - Add a `showAccountName` property to control whether account names are shown alongside assignee names.
  - Enhance filtering: users can now search by email as well as name or account name.
  - Sort assignees so that selected entries are always pinned at the top, with clear "Selected" and "Others" section headers. [[1]](diffhunk://#diff-37b69a28645d8f49152e2c819a0d64e53ac2081d62751255ba7bd933ea3f457dR293-R318) [[2]](diffhunk://#diff-37b69a28645d8f49152e2c819a0d64e53ac2081d62751255ba7bd933ea3f457dL485-R536)
  - Display the assignee's email address under their name in the selection list, and show the account name alongside the name when appropriate.
  - Remove redundant model property updates in the selection handler, relying on the new update logic.

These changes collectively improve the user experience when filtering, searching, and selecting assignees, and ensure that email information is consistently available and visible throughout the application.

**Backend changes:**
- Consistently retrieve an `email` field for users in assignee-related queries, prioritizing `login`, `email`, and `work_email` fields, and defaulting to an empty string if none are present. [[1]](diffhunk://#diff-b1ecf65ba963c97fb40a075e2200c035a341efbbc64402623540735d6e68f89dL161-R161) [[2]](diffhunk://#diff-ffedca43b6e03ad1c9c991575e672db67ea2f79e8720d7d92b2608858dd78261L1942-R1942) [[3]](diffhunk://#diff-4070379afe3dae54403330c28ec70f941eda2456cb6443b3609f1ed99e811629L3196-R3196)
- Ensure the `email` property is included in all assignee objects returned from activity and task queries. [[1]](diffhunk://#diff-ffedca43b6e03ad1c9c991575e672db67ea2f79e8720d7d92b2608858dd78261R1959) [[2]](diffhunk://#diff-4070379afe3dae54403330c28ec70f941eda2456cb6443b3609f1ed99e811629R3213)

**Frontend changes:**
- Pass the `email` property through to assignee objects in `Activity_Page.qml` and `Task_Page.qml` for use in the UI. [[1]](diffhunk://#diff-8c38d9ab4d2ca727ab5a84e4f188915973c4f6c5c71586d7ba0c991f1fb5b29fR394-R402) [[2]](diffhunk://#diff-8c38d9ab4d2ca727ab5a84e4f188915973c4f6c5c71586d7ba0c991f1fb5b29fR419-R432) [[3]](diffhunk://#diff-9ef01b287429d2039b4a877f22f248182da9f8e785077496d939f8b2d9b633c2R142-R150) [[4]](diffhunk://#diff-9ef01b287429d2039b4a877f22f248182da9f8e785077496d939f8b2d9b633c2R167-R181)
- Add a `showAccountName` property to `AssigneeFilterMenu.qml` to control whether account names are shown in the assignee list.
- Enhance assignee filtering and sorting: allow searching by email, pin selected assignees to the top, and display section headers for "Selected" and "Others". [[1]](diffhunk://#diff-37b69a28645d8f49152e2c819a0d64e53ac2081d62751255ba7bd933ea3f457dR241-R284) [[2]](diffhunk://#diff-37b69a28645d8f49152e2c819a0d64e53ac2081d62751255ba7bd933ea3f457dR293-R318) [[3]](diffhunk://#diff-37b69a28645d8f49152e2c819a0d64e53ac2081d62751255ba7bd933ea3f457dL485-R536)
- Display email addresses under assignee names and show account names as appropriate in the assignee selection UI.