### PR TITLE
Accountswitch drawerpatch

### DIFF
--- a/qml/Activity_Page.qml
+++ b/qml/Activity_Page.qml
@@ -162,6 +162,11 @@ Page {
 
         // Reload assignees for the new account
         loadAssignees();
+        assigneeFilterMenu.expanded = false;
+
+        // Reset assignee selection for the new account so stale IDs from the
+        // previous account do not make the refreshed list appear empty/stale.
+        applyDefaultAssigneeFilter();
 
         // Refresh the activity list
         isLoading = true;
@@ -487,9 +492,14 @@ Page {
                 activity.filterByAssignees = false;
                 activity.selectedAssigneeIds = [];
                 assigneeFilterMenu.selectedAssigneeIds = [];
+                Global.clearAssigneeFilter();
             }
         } catch (e) {
             console.error("applyDefaultAssigneeFilter failed:", e);
+            activity.filterByAssignees = false;
+            activity.selectedAssigneeIds = [];
+            assigneeFilterMenu.selectedAssigneeIds = [];
+            Global.clearAssigneeFilter();
         }
     }
 
@@ -819,14 +829,14 @@ Page {
 
         onAccountDataRefreshRequested: function (accountId) {
             //console.log("Activity_Page: Account data refresh requested for:", accountId);
-            if (activity.visible && accountId >= -1) {
+            if (activity.visible && accountId >= -1 && accountId !== selectedAccountId) {
                 handleAccountChange(accountId);
             }
         }
 
         onGlobalAccountChanged: function (accountId, accountName) {
             //console.log("Activity_Page: Global account changed to:", accountId, accountName);
-            if (activity.visible && accountId >= -1) {
+            if (activity.visible && accountId >= -1 && accountId !== selectedAccountId) {
                 handleAccountChange(accountId);
             }
         }

--- a/qml/Dashboard.qml
+++ b/qml/Dashboard.qml
@@ -117,13 +117,6 @@ Page {
                 }
             },
             Action {
-                iconName: "account"
-                text: i18n.dtr("ubtms", "Switch Accounts")
-                onTriggered: {
-                    accountPicker.open(accountPicker.selectedAccountId);
-                }
-            },
-            Action {
                 iconName: "reminder-new"
                 text: i18n.dtr("ubtms", "New Timesheet")
                 onTriggered: {

--- a/qml/Menu.qml
+++ b/qml/Menu.qml
@@ -99,6 +99,7 @@ Page {
                         NavigationMenuList {
                             width: parent.width
                             menuItems: MenuData.items()
+                            selectedPageUrl: apLayout && apLayout.currentMenuPageUrl ? apLayout.currentMenuPageUrl : ""
                             onItemSelected: function(item) {
                                 apLayout.setPageGlobal(item.pageUrl, item.pageNum)
                             }

--- a/qml/Menu.qml
+++ b/qml/Menu.qml
@@ -49,7 +49,14 @@ Page {
             dividerColor: LomiriColors.slate
         }
         trailingActionBar.actions: [
-                Action {
+            Action {
+                iconName: "account"
+                text: i18n.dtr("ubtms", "Switch Accounts")
+                onTriggered: {
+                    accountPicker.open(accountPicker.selectedAccountId);
+                }
+            },
+            Action {
                 iconSource: theme.name === "Ubuntu.Components.Themes.SuruDark" ? "images/daymode.png" : "images/darkmode.png"
                 text: theme.name === "Ubuntu.Components.Themes.SuruDark" ? i18n.dtr("ubtms", "Light Mode") : i18n.dtr("ubtms","Dark Mode")
                 onTriggered: {

--- a/qml/MyTasks.qml
+++ b/qml/MyTasks.qml
@@ -515,16 +515,6 @@ Page {
 
 
 
-    // Also listen to TSApp signals so account changes propagate even while this
-    // page is covered by another page in the navigation stack.
-    Connections {
-        target: accountPicker
-
-        onAccepted: function (id, name) {
-            handleAccountChange(id);
-        }
-    }
-
     Connections {
         target: typeof mainView !== 'undefined' ? mainView : null
 

--- a/qml/MyTasks.qml
+++ b/qml/MyTasks.qml
@@ -271,6 +271,18 @@ Page {
         }
     }
 
+    function clearCurrentTasks() {
+        personalStages = [];
+        currentPersonalStageId = undefined;
+        myTaskListHeader.filterModel = [];
+        myTaskListHeader.currentFilter = "";
+        myTasksList.currentOffset = 0;
+        myTasksList.hasMoreItems = false;
+        myTasksList.isLoadingMore = false;
+        myTasksList.isLoading = false;
+        myTasksList.updateDisplayedTasks([], false);
+    }
+
     // Function to handle account selection changes
     function handleAccountChange(accountId) {
         //console.log("MyTasks: Account changed to", accountId);
@@ -294,12 +306,21 @@ Page {
         // Update current user for the new account
         updateCurrentUser();
 
+        if (currentUserOdooId <= 0) {
+            clearCurrentTasks();
+            return;
+        }
+
         // Reload personal stages for the new account
         loadPersonalStages();
 
         // Refresh the task list with the first personal stage (paginated)
         if (currentUserOdooId > 0 && personalStages.length > 0 && currentPersonalStageId !== undefined) {
-            startPaginatedLoad();
+            loadTasksWithIndicator(function() {
+                startPaginatedLoad();
+            });
+        } else {
+            clearCurrentTasks();
         }
     }
 
@@ -494,20 +515,29 @@ Page {
 
 
 
-    // Also listen to TSApp signals for when MyTasks is already visible
+    // Also listen to TSApp signals so account changes propagate even while this
+    // page is covered by another page in the navigation stack.
+    Connections {
+        target: accountPicker
+
+        onAccepted: function (id, name) {
+            handleAccountChange(id);
+        }
+    }
+
     Connections {
         target: typeof mainView !== 'undefined' ? mainView : null
 
         function onAccountDataRefreshRequested(accountId) {
             // console.log("🔄 MyTasks: Refreshing data for account:", accountId);
-            if (myTasksPage.visible && accountId >= 0) {
+            if (accountId >= -1 && accountId !== selectedAccountId) {
                 handleAccountChange(accountId);
             }
         }
 
         function onGlobalAccountChanged(accountId, accountName) {
             //  console.log("🔄 MyTasks: Global account changed to:", accountId, accountName);
-            if (myTasksPage.visible && accountId >= 0) {
+            if (accountId >= -1 && accountId !== selectedAccountId) {
                 handleAccountChange(accountId);
             }
         }

--- a/qml/components/AppDrawer.qml
+++ b/qml/components/AppDrawer.qml
@@ -110,6 +110,7 @@ Controls.Drawer {
                         NavigationMenuList {
                             width: parent.width
                             menuItems: MenuData.items()
+                            selectedPageUrl: apLayout && apLayout.currentMenuPageUrl ? apLayout.currentMenuPageUrl : ""
                             onItemSelected: function(item) {
                                 drawerRoot.close()
                                 apLayout.setPageGlobal(item.pageUrl, item.pageNum)

--- a/qml/components/AppDrawer.qml
+++ b/qml/components/AppDrawer.qml
@@ -50,25 +50,50 @@ Controls.Drawer {
                         fontSize: "large"
                     }
 
-                    Item {
+                    Row {
                         anchors.verticalCenter: parent.verticalCenter
                         anchors.right: parent.right
                         anchors.rightMargin: units.gu(1.2)
-                        width: units.gu(4)
-                        height: units.gu(4)
+                        spacing: units.gu(0.8)
 
-                        Image {
-                            anchors.centerIn: parent
-                            width: units.gu(2.2)
-                            height: units.gu(2.2)
-                            source: theme.name === "Ubuntu.Components.Themes.SuruDark" ? Qt.resolvedUrl("../images/daymode.png") : Qt.resolvedUrl("../images/darkmode.png")
-                            fillMode: Image.PreserveAspectFit
+                        Item {
+                            width: units.gu(4)
+                            height: units.gu(4)
+
+                            Icon {
+                                anchors.centerIn: parent
+                                name: "account"
+                                width: units.gu(2.4)
+                                height: units.gu(2.4)
+                                color: "white"
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    drawerRoot.close();
+                                    accountPicker.open(accountPicker.selectedAccountId);
+                                }
+                            }
                         }
 
-                        MouseArea {
-                            anchors.fill: parent
-                            onClicked: {
-                                Theme.name = theme.name === "Ubuntu.Components.Themes.SuruDark" ? "Ubuntu.Components.Themes.Ambiance" : "Ubuntu.Components.Themes.SuruDark";
+                        Item {
+                            width: units.gu(4)
+                            height: units.gu(4)
+
+                            Image {
+                                anchors.centerIn: parent
+                                width: units.gu(2.2)
+                                height: units.gu(2.2)
+                                source: theme.name === "Ubuntu.Components.Themes.SuruDark" ? Qt.resolvedUrl("../images/daymode.png") : Qt.resolvedUrl("../images/darkmode.png")
+                                fillMode: Image.PreserveAspectFit
+                            }
+
+                            MouseArea {
+                                anchors.fill: parent
+                                onClicked: {
+                                    Theme.name = theme.name === "Ubuntu.Components.Themes.SuruDark" ? "Ubuntu.Components.Themes.Ambiance" : "Ubuntu.Components.Themes.SuruDark";
+                                }
                             }
                         }
                     }

--- a/qml/components/AppLayout.qml
+++ b/qml/components/AppLayout.qml
@@ -20,6 +20,7 @@ AdaptivePageLayout {
         property bool isMultiColumn: true
         property Page currentPage: splash_page
         property Page thirdPage: dashboard_page2
+        property string currentMenuPageUrl: "Dashboard.qml"
         primaryPage: splash_page
 
         function openGlobalDrawer() {
@@ -179,15 +180,18 @@ AdaptivePageLayout {
             case 1:
                 primaryPage = dashboard_page;
                 currentPage = dashboard_page;
+                currentMenuPageUrl = "Dashboard.qml";
                 break;
             case 2:
                 primaryPage = menu_page;
                 currentPage = dashboard_page;
+                currentMenuPageUrl = "Dashboard.qml";
                 addPageToNextColumn(primaryPage, currentPage);
                 break;
             case 3:
                 primaryPage = menu_page;
                 currentPage = dashboard_page;
+                currentMenuPageUrl = "Dashboard.qml";
                 addPageToNextColumn(primaryPage, currentPage);
                 addPageToNextColumn(currentPage, thirdPage);
                 break;
@@ -218,6 +222,7 @@ AdaptivePageLayout {
         if (targetPage !== null) {
             apLayout.currentPage = targetPage;
         }
+        currentMenuPageUrl = url;
         
         if (apLayout.columns === 1) {
             // For single column, replace primary page to dodge back-stack

--- a/qml/components/GlobalWidgets.qml
+++ b/qml/components/GlobalWidgets.qml
@@ -47,12 +47,18 @@ Item {
         restrictToLocalOnly: false
 
         onAccepted: function (id, name) {
-            if(rootApp) {
-                rootApp.currentAccountId = id;
-                rootApp.currentAccountName = name;
-                rootApp.globalAccountChanged(id, name);
-                rootApp.accountDataRefreshRequested(id);
+            if (!rootApp) {
+                return;
             }
+
+            if (rootApp.currentAccountId === id) {
+                return;
+            }
+
+            rootApp.currentAccountId = id;
+            rootApp.currentAccountName = name;
+            rootApp.globalAccountChanged(id, name);
+            rootApp.accountDataRefreshRequested(id);
         }
     }
 

--- a/qml/components/GlobalWidgets.qml
+++ b/qml/components/GlobalWidgets.qml
@@ -50,6 +50,8 @@ Item {
             if(rootApp) {
                 rootApp.currentAccountId = id;
                 rootApp.currentAccountName = name;
+                rootApp.globalAccountChanged(id, name);
+                rootApp.accountDataRefreshRequested(id);
             }
         }
     }

--- a/qml/components/NavigationMenuList.qml
+++ b/qml/components/NavigationMenuList.qml
@@ -7,6 +7,7 @@ Column {
     width: parent ? parent.width : 0
 
     property var menuItems: []
+    property string selectedPageUrl: ""
     signal itemSelected(var item)
 
     Repeater {
@@ -18,6 +19,7 @@ Column {
             iconColor: modelData.iconColor
             text: i18n.dtr("ubtms", modelData.textKey)
             showDivider: modelData.showDivider === undefined ? true : modelData.showDivider
+            active: modelData.pageUrl === root.selectedPageUrl
             onClicked: root.itemSelected(modelData)
         }
     }

--- a/qml/components/settings/SettingsListItem.qml
+++ b/qml/components/settings/SettingsListItem.qml
@@ -50,6 +50,7 @@ Item {
     property color iconColor: "#666"
     property bool showProgression: true
     property bool showDivider: true
+    property bool active: false
 
     signal clicked()
 
@@ -57,17 +58,28 @@ Item {
     readonly property bool isDark: theme.name === "Ubuntu.Components.Themes.SuruDark"
     readonly property color bgColor: isDark ? "#1e1e1e" : "#ffffff"
     readonly property color bgPressedColor: isDark ? "#2a2a2a" : "#f0f0f0"
-    readonly property color textColor: isDark ? "#e0e0e0" : "#333333"
+    readonly property color bgActiveColor: isDark ? "#2b241b" : "#fff1de"
+    readonly property color textColor: active ? LomiriColors.orange : (isDark ? "#e0e0e0" : "#333333")
     readonly property color dividerColor: isDark ? "#333333" : "#e8e8e8"
-    readonly property color chevronColor: isDark ? "#666666" : "#c7c7cc"
+    readonly property color chevronColor: active ? LomiriColors.orange : (isDark ? "#666666" : "#c7c7cc")
 
     Rectangle {
         id: background
         anchors.fill: parent
-        color: mouseArea.pressed ? root.bgPressedColor : root.bgColor
+        color: mouseArea.pressed ? root.bgPressedColor : (root.active ? root.bgActiveColor : root.bgColor)
 
         Behavior on color {
             ColorAnimation { duration: 120 }
+        }
+
+        Rectangle {
+            anchors.left: parent.left
+            anchors.verticalCenter: parent.verticalCenter
+            width: units.dp(3)
+            height: parent.height - units.gu(1.6)
+            radius: units.dp(2)
+            color: LomiriColors.orange
+            visible: root.active
         }
 
         Row {
@@ -100,6 +112,7 @@ Item {
                     text: root.text
                     font.pixelSize: units.gu(2)
                     color: root.textColor
+                    font.bold: root.active
                     elide: Text.ElideRight
                     width: parent.width
                 }

--- a/qml/components/settings/SettingsListItem.qml
+++ b/qml/components/settings/SettingsListItem.qml
@@ -112,7 +112,7 @@ Item {
                     text: root.text
                     font.pixelSize: units.gu(2)
                     color: root.textColor
-                    font.bold: root.active
+                 //   font.bold: root.active
                     elide: Text.ElideRight
                     width: parent.width
                 }

--- a/qml/components/settings/SettingsListItem.qml
+++ b/qml/components/settings/SettingsListItem.qml
@@ -112,7 +112,6 @@ Item {
                     text: root.text
                     font.pixelSize: units.gu(2)
                     color: root.textColor
-                 //   font.bold: root.active
                     elide: Text.ElideRight
                     width: parent.width
                 }

--- a/qml/settings/Settings_Page.qml
+++ b/qml/settings/Settings_Page.qml
@@ -30,8 +30,15 @@ import "../components/settings"
 Page {
     id: settings
     property bool isMultiColumn: apLayout.columns > 1
+    property string selectedSettingsPageUrl: ""
 
     title: i18n.dtr("ubtms", "Settings")
+
+    onVisibleChanged: {
+        if (visible && !isMultiColumn) {
+            selectedSettingsPageUrl = "";
+        }
+    }
 
     header: SettingsHeader {
         id: pageHeader
@@ -60,7 +67,9 @@ Page {
             iconName: "contact-group"
             iconColor: "#2980b9"
             text: i18n.dtr("ubtms", "Connected Accounts")
+            active: settings.selectedSettingsPageUrl === "Settings_Accounts.qml"
             onClicked: {
+                settings.selectedSettingsPageUrl = "Settings_Accounts.qml";
                 apLayout.addPageToNextColumn(settings, Qt.resolvedUrl('Settings_Accounts.qml'));
             }
         }
@@ -69,7 +78,9 @@ Page {
             iconName: "notification"
             iconColor: "#e74c3c"
             text: i18n.dtr("ubtms", "Notifications")
+            active: settings.selectedSettingsPageUrl === "Settings_Notifications.qml"
             onClicked: {
+                settings.selectedSettingsPageUrl = "Settings_Notifications.qml";
                 apLayout.addPageToNextColumn(settings, Qt.resolvedUrl('Settings_Notifications.qml'));
             }
         }
@@ -78,7 +89,9 @@ Page {
             iconName: "sync-idle"
             iconColor: "#27ae60"
             text: i18n.dtr("ubtms", "Background Sync")
+            active: settings.selectedSettingsPageUrl === "Settings_Sync.qml"
             onClicked: {
+                settings.selectedSettingsPageUrl = "Settings_Sync.qml";
                 apLayout.addPageToNextColumn(settings, Qt.resolvedUrl('Settings_Sync.qml'));
             }
         }
@@ -87,8 +100,10 @@ Page {
             iconName: "preferences-desktop-theme"
             iconColor: "#8e44ad"
             text: i18n.dtr("ubtms", "Theme Settings")
+            active: settings.selectedSettingsPageUrl === "Settings_Theme.qml"
             showDivider: false
             onClicked: {
+                settings.selectedSettingsPageUrl = "Settings_Theme.qml";
                 apLayout.addPageToNextColumn(settings, Qt.resolvedUrl('Settings_Theme.qml'));
             }
         }


### PR DESCRIPTION
This pull request introduces several improvements across the UI, focusing on better account switching, improved menu highlighting, and enhanced state management when accounts or pages change. The most important changes are grouped below:

**Account Switching Improvements:**

* Added a global "Switch Accounts" action to the main menu and app drawer, making account switching more accessible throughout the app. The icon and action now consistently open the `accountPicker`. (`qml/Menu.qml`, `qml/components/AppDrawer.qml`) [[1]](diffhunk://#diff-4341364cac101aa927ff3ee952eac1fc07c0dec5028100eb4e83634cd611aab6R52-R58) [[2]](diffhunk://#diff-3536429b5dd6cf5cddf643a98fec7ef35babccc66a2f0f4465d888eea4d1c02eL53-R80)
* Improved account change handling in `Activity_Page.qml` and `MyTasks.qml` to prevent stale state and ensure task/assignee lists are reset or refreshed appropriately when accounts change. This includes clearing filters and selections, and resetting lists if the user is invalid or missing. (`qml/Activity_Page.qml`, `qml/MyTasks.qml`) [[1]](diffhunk://#diff-8c38d9ab4d2ca727ab5a84e4f188915973c4f6c5c71586d7ba0c991f1fb5b29fR165-R169) [[2]](diffhunk://#diff-8c38d9ab4d2ca727ab5a84e4f188915973c4f6c5c71586d7ba0c991f1fb5b29fR495-R502) [[3]](diffhunk://#diff-dbd45983a6f18612543bf26db6b728b4f096b52296a085d620d7e6939097863cR274-R285) [[4]](diffhunk://#diff-dbd45983a6f18612543bf26db6b728b4f096b52296a085d620d7e6939097863cR309-R323)

**Menu Highlighting and Navigation:**

* Added a `selectedPageUrl` property to the navigation menu and settings menu, and updated the `SettingsListItem` component to visually highlight the active menu item. This provides clear feedback about which page is currently selected. (`qml/components/NavigationMenuList.qml`, `qml/components/settings/SettingsListItem.qml`, `qml/settings/Settings_Page.qml`) [[1]](diffhunk://#diff-e4622d90e8adf99c7f3e55384dc33922b82eccbb824b6cf4c9a64a44d3c9506dR10) [[2]](diffhunk://#diff-e4622d90e8adf99c7f3e55384dc33922b82eccbb824b6cf4c9a64a44d3c9506dR22) [[3]](diffhunk://#diff-7a910419c04ad8203509ee5bbed38a018db6973f9f4499cafd9a87cc52bac379R53-R84) [[4]](diffhunk://#diff-a92fddecbc34d57bdfb8b214f60f3040cfde32621080a74663478891538531d2R70-R72) [[5]](diffhunk://#diff-a92fddecbc34d57bdfb8b214f60f3040cfde32621080a74663478891538531d2R81-R83) [[6]](diffhunk://#diff-a92fddecbc34d57bdfb8b214f60f3040cfde32621080a74663478891538531d2R92-R94) [[7]](diffhunk://#diff-a92fddecbc34d57bdfb8b214f60f3040cfde32621080a74663478891538531d2R103-R106)
* The `AppLayout` component now tracks and updates the current menu page URL, ensuring the correct menu item is highlighted as users navigate. (`qml/components/AppLayout.qml`) [[1]](diffhunk://#diff-0f2e22158726916c6b0fb4d7f3fce7b8bc7dce02bd2f71316d4fa4ac61a69910R23) [[2]](diffhunk://#diff-0f2e22158726916c6b0fb4d7f3fce7b8bc7dce02bd2f71316d4fa4ac61a69910R183-R194) [[3]](diffhunk://#diff-0f2e22158726916c6b0fb4d7f3fce7b8bc7dce02bd2f71316d4fa4ac61a69910R225)

**State Synchronization and Bug Fixes:**

* Ensured account-related signals (`globalAccountChanged`, `accountDataRefreshRequested`) are emitted in the correct sequence for more robust state updates across the app. (`qml/components/GlobalWidgets.qml`)
* Improved signal handling so that account changes propagate even when a page is not currently visible, preventing outdated data from being displayed. (`qml/MyTasks.qml`)
* Fixed logic in event handlers to avoid redundant refreshes when the selected account hasn't actually changed. (`qml/Activity_Page.qml`, `qml/MyTasks.qml`) [[1]](diffhunk://#diff-8c38d9ab4d2ca727ab5a84e4f188915973c4f6c5c71586d7ba0c991f1fb5b29fL822-R839) [[2]](diffhunk://#diff-dbd45983a6f18612543bf26db6b728b4f096b52296a085d620d7e6939097863cL497-R540)

These changes collectively enhance the user experience by making account switching more intuitive and reliable, improving navigation clarity, and ensuring that UI state remains consistent across account and page transitions.