### PR TITLE
Draft patch

### DIFF
--- a/qml/components/dialogs/CreateUpdateDialog.qml
+++ b/qml/components/dialogs/CreateUpdateDialog.qml
@@ -50,8 +50,7 @@ Item {
             onVisibleChanged: {
                 if (visible) {
                     // Check if content was updated in ReadMorePage
-                    if (Global.description_temporary_holder !== "" && 
-                        Global.description_temporary_holder !== lastKnownContent) {
+                    if (Global.description_temporary_holder !== lastKnownContent) {
                         descriptionField.setContent(Global.description_temporary_holder);
                         lastKnownContent = Global.description_temporary_holder;
                     }

--- a/qml/components/richtext/ReadMorePage.qml
+++ b/qml/components/richtext/ReadMorePage.qml
@@ -361,7 +361,7 @@ Page {
         running: !isReadOnly
         onTriggered: {
             var holderContent = Global.description_temporary_holder;
-            if (holderContent !== "" && holderContent !== readmepage._lastKnownHolder) {
+            if (holderContent !== readmepage._lastKnownHolder) {
                // console.log("[ReadMorePage] External change detected - PULLING from Global, length:", holderContent.length);
                 readmepage._lastKnownHolder = holderContent;
                 if (useRichText && editor) {

--- a/qml/components/richtext/RichTextPreview.qml
+++ b/qml/components/richtext/RichTextPreview.qml
@@ -325,7 +325,7 @@ Rectangle {
         running: root.liveSyncActive
         onTriggered: {
             var holderContent = Global.description_temporary_holder;
-            if (holderContent !== "" && holderContent !== root._lastSyncedContent) {
+            if (holderContent !== root._lastSyncedContent) {
                // console.log("[RichTextPreview] External change detected - PULLING from Global, length:", holderContent.length);
                 root._lastSyncedContent = holderContent;
                 root.setContent(holderContent);

--- a/qml/components/richtext/js/editor.html
+++ b/qml/components/richtext/js/editor.html
@@ -278,8 +278,17 @@
                 // Track content changes
                 var lastContent = '';
 
+                // Strip script tags from Squire's getHTML() output.
+                // Squire returns the full body innerHTML including bridge/setup
+                // scripts; we only want the actual user content.
+                function stripScripts(html) {
+                    if (!html) return '';
+                    return html.replace(/<script[\s\S]*?<\/script>/gi, '').replace(/^\s+|\s+$/g, '');
+                }
+
                 window.editor.addEventListener('input', function () {
-                    var content = window.editor.getHTML();
+                    var rawContent = window.editor.getHTML();
+                    var content = stripScripts(rawContent);
                     if (content !== lastContent) {
                         lastContent = content;
                         oxide.sendMessage('contentChanged', { content: content });

--- a/qml/components/workflow/CreateUpdatePage.qml
+++ b/qml/components/workflow/CreateUpdatePage.qml
@@ -197,7 +197,7 @@ Page {
             descriptionField.liveSyncActive = false;
 
             // Check if content was updated in ReadMorePage
-            if (Global.description_temporary_holder !== "") {
+            if (Global.description_temporary_holder !== "" || lastKnownContent !== "") {
                 descriptionField.setContent(Global.description_temporary_holder);
                 lastKnownContent = Global.description_temporary_holder;
                 draftHandler.markFieldChanged("description", Global.description_temporary_holder);

--- a/qml/components/workflow/CreateUpdatePage.qml
+++ b/qml/components/workflow/CreateUpdatePage.qml
@@ -39,6 +39,18 @@ Page {
         onDraftLoaded: function(draftData, changedFields) {
             console.log("📋 Loading draft for project update, changed fields:", changedFields);
             
+            // Restore project/account selection from draft
+            var draftAccountId = -1;
+            var draftProjectId = -1;
+            if (draftData.accountId !== undefined && draftData.accountId > 0) {
+                createUpdatePage.accountId = draftData.accountId;
+                draftAccountId = draftData.accountId;
+            }
+            if (draftData.projectId !== undefined && draftData.projectId > 0) {
+                createUpdatePage.projectId = draftData.projectId;
+                draftProjectId = draftData.projectId;
+            }
+            
             // Restore form fields from draft
             if (draftData.title !== undefined) {
                 titleField.text = draftData.title;
@@ -55,6 +67,23 @@ Page {
             if (draftData.description !== undefined) {
                 descriptionField.setContent(draftData.description);
                 lastKnownContent = draftData.description;
+            }
+            
+            // Re-initialize WorkItemSelector with draft project/account values.
+            // loadAccounts emits AccountSelected synchronously which resets projectId to -1,
+            // and loadProjects (via finalizeLoading) does NOT emit ProjectSelected.
+            // So we must restore projectId AFTER the initialization settles.
+            if (workItemSelector.isInitialized && draftProjectId > 0) {
+                workItemSelector.initializeWorkItemSelector();
+                // Restore projectId after loadAccounts' AccountSelected reset and loadProjects' Qt.callLater
+                Qt.callLater(function() {
+                    Qt.callLater(function() {
+                        createUpdatePage.projectId = draftProjectId;
+                        if (draftAccountId > 0) {
+                            createUpdatePage.accountId = draftAccountId;
+                        }
+                    });
+                });
             }
             
             // Show notification about recovered draft

--- a/qml/features/activities/pages/Activities.qml
+++ b/qml/features/activities/pages/Activities.qml
@@ -1237,7 +1237,7 @@ Page {
             } else {
             }
 
-            if (Global.description_temporary_holder !== "" && Global.description_context === "activity_notes") {
+            if (Global.description_context === "activity_notes") {
                 //Check if you are coming back from the ReadMore page
                 
                 // Temporarily set isInitializing to avoid triggering during setContent

--- a/qml/features/projects/pages/Projects.qml
+++ b/qml/features/projects/pages/Projects.qml
@@ -1083,7 +1083,7 @@ Page {
         if (visible) {
             // Stop live sync — content is already up-to-date via the timer
             description_text.liveSyncActive = false;
-            if (Global.description_temporary_holder !== "" && Global.description_context === "project_description") {
+            if (Global.description_context === "project_description") {
                 //Check if you are coming back from the ReadMore page for project description
                 description_text.setContent(Global.description_temporary_holder);
                 Global.description_temporary_holder = "";

--- a/qml/features/tasks/pages/Tasks.qml
+++ b/qml/features/tasks/pages/Tasks.qml
@@ -1040,7 +1040,7 @@ Page {
             // Stop live sync — content is already up-to-date via the timer
             description_text.liveSyncActive = false;
 
-            if (Global.description_temporary_holder !== "") {
+            if (navigatingToReadMore || Global.description_temporary_holder !== "") {
                 //Check if you are coming back from the ReadMore page
                 description_text.setContent(Global.description_temporary_holder);
                 Global.description_temporary_holder = "";

--- a/qml/features/timesheets/pages/Timesheet.qml
+++ b/qml/features/timesheets/pages/Timesheet.qml
@@ -841,7 +841,7 @@ Page {
             // Stop live sync — content is already up-to-date via the timer
             description_text.liveSyncActive = false;
             
-            if (Global.description_temporary_holder !== "") {
+            if (Global.description_temporary_holder !== "" || navigatingToReadMore) {
                 //Check if you are coming back from the ReadMore page
                 description_text.setContent(Global.description_temporary_holder);
                 Global.description_temporary_holder = "";

--- a/qml/features/updates/pages/Updates.qml
+++ b/qml/features/updates/pages/Updates.qml
@@ -231,6 +231,21 @@ Page {
         
         isRestoringFromDraft = true;
         
+        // Restore project/account/user selection from draft
+        var draftProjectId = -1;
+        var draftAccountId = -1;
+        if (draftData.account_id !== undefined && draftData.account_id > 0) {
+            currentUpdate.account_id = draftData.account_id;
+            draftAccountId = draftData.account_id;
+        }
+        if (draftData.project_id !== undefined && draftData.project_id > 0) {
+            currentUpdate.project_id = draftData.project_id;
+            draftProjectId = draftData.project_id;
+        }
+        if (draftData.user_id !== undefined && draftData.user_id > 0) {
+            currentUpdate.user_id = draftData.user_id;
+        }
+        
         if (draftData.name !== undefined) {
             name_text.text = draftData.name;
         }
@@ -245,6 +260,29 @@ Page {
         }
         if (draftData.progress !== undefined) {
             progressSlider.value = draftData.progress;
+        }
+        
+        // Update display names after restoring project/account
+        updateDisplayNames();
+        
+        // Re-initialize WorkItemSelector with draft project/account values.
+        // loadAccounts emits AccountSelected synchronously which resets project_id to -1,
+        // and loadProjects (via finalizeLoading) does NOT emit ProjectSelected.
+        // So we must restore project_id AFTER the initialization settles.
+        if (needsProjectSelection && workItemSelector.isInitialized) {
+            workItemSelector.initializeWorkItemSelector();
+            // Restore project_id after loadAccounts' AccountSelected reset and loadProjects' Qt.callLater
+            if (draftProjectId > 0) {
+                Qt.callLater(function() {
+                    Qt.callLater(function() {
+                        currentUpdate.project_id = draftProjectId;
+                        if (draftAccountId > 0) {
+                            currentUpdate.account_id = draftAccountId;
+                        }
+                        updateDisplayNames();
+                    });
+                });
+            }
         }
         
         Qt.callLater(function() {
@@ -347,6 +385,7 @@ Page {
                     
                     // Load accounts with the default account pre-selected
                     var accountToSelect = currentUpdate.account_id >= 0 ? currentUpdate.account_id : defaultAccountId;
+                    // Capture project_id BEFORE loadAccounts resets it via AccountSelected
                     var projectToSelect = (currentUpdate.project_id && currentUpdate.project_id > 0) ? currentUpdate.project_id : -1;
                     loadAccounts(accountToSelect);
                     

--- a/qml/features/updates/pages/Updates.qml
+++ b/qml/features/updates/pages/Updates.qml
@@ -807,7 +807,7 @@ Page {
                 currentUpdate = Project.getProjectUpdateById(recordid, accountid);
             }
             
-            if (Global.description_temporary_holder !== "" && Global.description_context === "update_description") {
+            if (Global.description_context === "update_description") {
                 var wasInitializing = isInitializing;
                 isInitializing = true;
                 description_text.setContent(Global.description_temporary_holder);


### PR DESCRIPTION
This pull request focuses on improving the restoration of draft data (especially project/account selection) and streamlining the logic for syncing and restoring rich text content across multiple QML pages. It also introduces a security fix to strip script tags from the HTML content returned by the rich text editor. The main themes are: (1) improved draft restoration for project/account selection, (2) more robust and consistent content restoration from the global temporary holder, and (3) security and content handling enhancements in the rich text editor.

**Draft restoration and project/account selection improvements:**

* `qml/components/workflow/CreateUpdatePage.qml`, `qml/features/updates/pages/Updates.qml`: Enhanced draft restoration logic to properly restore project/account/user selection from drafts. This includes capturing and re-applying selection after asynchronous initialization of selectors, ensuring the correct project/account is set even if intermediate signals reset their values. [[1]](diffhunk://#diff-1991b2f7d7dd3182f643e5d6c689ca58954d41a0dcdeda4a53877e1530c127d6R42-R53) [[2]](diffhunk://#diff-1991b2f7d7dd3182f643e5d6c689ca58954d41a0dcdeda4a53877e1530c127d6R72-R88) [[3]](diffhunk://#diff-707d838a6c45b029e4ab2148282083fba896d34ef514dd378ee07e5741d467ccR234-R248) [[4]](diffhunk://#diff-707d838a6c45b029e4ab2148282083fba896d34ef514dd378ee07e5741d467ccR265-R287) [[5]](diffhunk://#diff-707d838a6c45b029e4ab2148282083fba896d34ef514dd378ee07e5741d467ccR388)
* [`qml/features/updates/pages/Updates.qml`](diffhunk://#diff-707d838a6c45b029e4ab2148282083fba896d34ef514dd378ee07e5741d467ccR265-R287): Ensures display names are updated after restoring project/account from draft, and re-initializes selectors as needed.

**Content restoration and live sync logic:**

* Multiple files (`qml/components/dialogs/CreateUpdateDialog.qml`, `qml/components/richtext/ReadMorePage.qml`, `qml/components/richtext/RichTextPreview.qml`, `qml/features/activities/pages/Activities.qml`, `qml/features/projects/pages/Projects.qml`, `qml/features/tasks/pages/Tasks.qml`, `qml/features/timesheets/pages/Timesheet.qml`, `qml/features/updates/pages/Updates.qml`): Simplified and unified the logic for restoring content from `Global.description_temporary_holder`. Checks for non-empty strings are removed in favor of context-based or navigation-based checks, making restoration more robust and less error-prone when returning from the ReadMore page. [[1]](diffhunk://#diff-5b68aa4237c3efd633ea650e403a300973e4e9c6136bb0c8c1b811d25286e17eL53-R53) [[2]](diffhunk://#diff-19b3c0ff7ef794e68ec19d7416b5e06d2eafacd3ce269e1cea92ddf4f603d29bL364-R364) [[3]](diffhunk://#diff-f7151af578415c3d07e3c20be45884c84c12566b07938b26f6b9b9908faf5b51L328-R328) [[4]](diffhunk://#diff-a2955a20f9bd86c467540cb391e7b24a423d745691763679aebfa2b92f9f5f5dL1240-R1240) [[5]](diffhunk://#diff-74a7a438ecad54ae3c8a29dcf53ed6fcca855920b24017e65255d7217c55f579L1086-R1086) [[6]](diffhunk://#diff-fd0c260646acd24f8b8cd9095cf50163f87de08f7283420bce806abd41abda71L1043-R1043) [[7]](diffhunk://#diff-24e74b572fd662cfc76db7ddc8fe375f67298bc60036b111913f31c15e4ea080L844-R844) [[8]](diffhunk://#diff-707d838a6c45b029e4ab2148282083fba896d34ef514dd378ee07e5741d467ccL810-R849) [[9]](diffhunk://#diff-1991b2f7d7dd3182f643e5d6c689ca58954d41a0dcdeda4a53877e1530c127d6L200-R229)

**Rich text editor security and content handling:**

* [`qml/components/richtext/js/editor.html`](diffhunk://#diff-47cb38df16facc96d9a6178b1e9b6d9f6fe095afb691bf71bc9a66d120f1b62fR281-R291): Added a function to strip `<script>` tags from the HTML returned by Squire's `getHTML()`, preventing bridge/setup scripts from being included in user content. This is a security improvement and ensures only user content is processed.

These changes together improve the reliability of draft restoration and content syncing across the application, while also addressing a potential security issue in the rich text editor.