### PR TITLE
Fontsize factor patch

### DIFF
--- a/qml/components/richtext/FontSizeDialog.qml
+++ b/qml/components/richtext/FontSizeDialog.qml
@@ -31,18 +31,22 @@ Dialog {
         
         Repeater {
             model: [
-                { label: "8pt", value: "8pt" },
-                { label: "9pt", value: "9pt" },
-                { label: "10pt", value: "10pt" },
-                { label: "11pt", value: "11pt" },
-                { label: "12pt", value: "12pt" },
-                { label: "14pt", value: "14pt" },
-                { label: "16pt", value: "16pt" },
-                { label: "18pt", value: "18pt" },
-                { label: "20pt", value: "20pt" },
-                { label: "24pt", value: "24pt" },
-                { label: "36pt", value: "36pt" },
-                { label: "48pt", value: "48pt" }
+                { label: "8px", value: "8px" },
+                { label: "9px", value: "9px" },
+                { label: "10px", value: "10px" },
+                { label: "11px", value: "11px" },
+                { label: "12px", value: "12px" },
+                { label: "13px", value: "13px" },
+                { label: "14px", value: "14px" },
+                { label: "16px", value: "16px" },
+                { label: "18px", value: "18px" },
+                { label: "20px", value: "20px" },
+                { label: "24px", value: "24px" },
+                { label: "28px", value: "28px" },
+                { label: "32px", value: "32px" },
+                { label: "36px", value: "36px" },
+                { label: "48px", value: "48px" },
+                { label: "64px", value: "64px" }
             ]
             
             AbstractButton {

--- a/qml/components/richtext/FontSizeDialog.qml
+++ b/qml/components/richtext/FontSizeDialog.qml
@@ -26,47 +26,60 @@ Dialog {
  
     signal sizeSelected(string size)
     
-    Column {
-        spacing: units.gu(0.5)
+    Flickable {
+        width: parent.width
+        height: Math.min(units.gu(40), sizeColumn.implicitHeight)
+        contentHeight: sizeColumn.implicitHeight
+        clip: true
         
-        Repeater {
-            model: [
-                { label: "8px", value: "8px" },
-                { label: "9px", value: "9px" },
-                { label: "10px", value: "10px" },
-                { label: "11px", value: "11px" },
-                { label: "12px", value: "12px" },
-                { label: "13px", value: "13px" },
-                { label: "14px", value: "14px" },
-                { label: "16px", value: "16px" },
-                { label: "18px", value: "18px" },
-                { label: "20px", value: "20px" },
-                { label: "24px", value: "24px" },
-                { label: "28px", value: "28px" },
-                { label: "32px", value: "32px" },
-                { label: "36px", value: "36px" },
-                { label: "48px", value: "48px" },
-                { label: "64px", value: "64px" }
-            ]
+        Column {
+            id: sizeColumn
+            width: parent.width
+            spacing: units.gu(0.5)
             
-            AbstractButton {
-                width: parent.width
-                height: units.gu(4)
+            Repeater {
+                model: [
+                    { label: "8px", value: "8px" },
+                    { label: "9px", value: "9px" },
+                    { label: "10px", value: "10px" },
+                    { label: "11px", value: "11px" },
+                    { label: "12px", value: "12px" },
+                    { label: "13px", value: "13px" },
+                    { label: "14px", value: "14px" },
+                    { label: "16px", value: "16px" },
+                    { label: "18px", value: "18px" },
+                    { label: "20px", value: "20px" },
+                    { label: "24px", value: "24px" },
+                    { label: "28px", value: "28px" },
+                    { label: "32px", value: "32px" },
+                    { label: "36px", value: "36px" },
+                    { label: "48px", value: "48px" },
+                    { label: "56px", value: "56px" },
+                    { label: "64px", value: "64px" },
+                    { label: "72px", value: "72px" },
+                    { label: "80px", value: "80px" },
+                    { label: "96px", value: "96px" }
+                ]
                 
-                Rectangle {
-                    anchors.fill: parent
-                    color: parent.pressed ? "#E0E0E0" : "transparent"
-                }
-                
-                Label {
-                    anchors.centerIn: parent
-                    text: modelData.label
-                    fontSize: "medium"
-                }
-                
-                onClicked: {
-                    sizeDialog.sizeSelected(modelData.value)
-                    PopupUtils.close(sizeDialog)
+                AbstractButton {
+                    width: parent.width
+                    height: units.gu(4)
+                    
+                    Rectangle {
+                        anchors.fill: parent
+                        color: parent.pressed ? "#E0E0E0" : "transparent"
+                    }
+                    
+                    Label {
+                        anchors.centerIn: parent
+                        text: modelData.label
+                        fontSize: "medium"
+                    }
+                    
+                    onClicked: {
+                        sizeDialog.sizeSelected(modelData.value)
+                        PopupUtils.close(sizeDialog)
+                    }
                 }
             }
         }

--- a/qml/components/richtext/HtmlEditorContainer.qml
+++ b/qml/components/richtext/HtmlEditorContainer.qml
@@ -48,7 +48,7 @@ Item {
     property alias editor: htmlEditor
     
     /** Current font size display */
-    property string currentFontSize: htmlEditor ? htmlEditor.currentFontSize : "12pt"
+    property string currentFontSize: htmlEditor ? htmlEditor.currentFontSize : "13px"
     
     /** Current text color */
     property color currentTextColor: htmlEditor ? htmlEditor.currentTextColor : "#000000"

--- a/qml/components/richtext/HtmlEditorToolbar.qml
+++ b/qml/components/richtext/HtmlEditorToolbar.qml
@@ -27,7 +27,7 @@ Rectangle {
     property var editor: null
     
     // Dynamic properties - bound to editor when available
-    property string currentFontSize: editor ? editor.currentFontSize : "12pt"
+    property string currentFontSize: editor ? editor.currentFontSize : "13px"
     property color currentTextColor: editor ? editor.currentTextColor : "#000000"
     property color currentHighlightColor: editor ? editor.currentHighlightColor : "transparent"
     property bool darkMode: theme.name === "Ubuntu.Components.Themes.SuruDark"

--- a/qml/components/richtext/RichTextEditor.qml
+++ b/qml/components/richtext/RichTextEditor.qml
@@ -50,8 +50,8 @@ Item {
      */
     property alias font: p.font
 
-    /** Current font size at cursor position (e.g., "12pt", "16px") */
-    property string currentFontSize: "12pt"
+    /** Current font size at cursor position (e.g., "13px", "16px") */
+    property string currentFontSize: "13px"
     
     /** Current text color at cursor position */
     property color currentTextColor: "#000000"
@@ -578,7 +578,7 @@ Item {
         anchors.right: parent.right
         anchors.bottom: parent.bottom
         anchors.bottomMargin: editor._oskHeight
-        zoomFactor: isMultiColumn ? 1.0 : 2.52
+        zoomFactor: units.dp(1)
         backgroundColor: darkMode ? "#2d2d2d" : "#ffffff"
         
         url: Qt.resolvedUrl("js/editor.html") + "?darkMode=" + darkMode + 

--- a/qml/components/richtext/js/editor.html
+++ b/qml/components/richtext/js/editor.html
@@ -166,6 +166,20 @@
         body::-webkit-scrollbar-thumb:hover {
             background: var(--placeholder-color);
         }
+
+        /* Odoo Font Size classes mapping */
+        .display-1-fs { font-size: 96px !important; }
+        .display-2-fs { font-size: 80px !important; }
+        .display-3-fs { font-size: 64px !important; }
+        .display-4-fs { font-size: 56px !important; }
+        .h1-fs { font-size: 40px !important; }
+        .h2-fs { font-size: 32px !important; }
+        .h3-fs { font-size: 28px !important; }
+        .h4-fs { font-size: 24px !important; }
+        .h5-fs { font-size: 20px !important; }
+        .h6-fs { font-size: 16px !important; }
+        .small { font-size: 11px !important; }
+        .base-fs { font-size: 13px !important; }
     </style>
 </head>
 

--- a/qml/components/richtext/js/editor.html
+++ b/qml/components/richtext/js/editor.html
@@ -316,14 +316,19 @@
                 var lastHoveredFormattingStr = null;
                 var hoverTimer = null;
 
-                function formatPxToPt(sizeStr) {
-                    if (!sizeStr) return "12pt";
-                    if (sizeStr.endsWith("pt")) return sizeStr;
+                function formatFontSize(sizeStr) {
+                    if (!sizeStr) return "13px";
                     if (sizeStr.endsWith("px")) {
-                        var px = parseFloat(sizeStr);
+                        var px = Math.round(parseFloat(sizeStr));
                         if (!isNaN(px)) {
-                            var pt = Math.round(px * 0.75);
-                            return pt + "pt";
+                            return px + "px";
+                        }
+                    }
+                    if (sizeStr.endsWith("pt")) {
+                        var pt = parseFloat(sizeStr);
+                        if (!isNaN(pt)) {
+                            var pxVal = Math.round(pt * 1.3333);
+                            return pxVal + "px";
                         }
                     }
                     return sizeStr;
@@ -365,7 +370,7 @@
 
                     var color = rgbToHex(comp.color || '#000000');
                     var bgColor = rgbToHex(comp.backgroundColor || 'transparent');
-                    var fontSize = formatPxToPt(comp.fontSize || '12pt');
+                    var fontSize = formatFontSize(comp.fontSize || '13px');
 
                     return {
                         fontSize: fontSize,

--- a/qml/components/richtext/js/html-sanitizer.js
+++ b/qml/components/richtext/js/html-sanitizer.js
@@ -30,6 +30,10 @@ function sanitize(html, options) {
     // Step 2: Clean Qt-specific styles
     result = cleanQtStyles(result);
     
+    // Step 2b: Convert Odoo CSS class-based font sizes to inline styles
+    // (enables Qt TextArea and Squire to render them correctly)
+    result = normalizeOdooClasses(result);
+    
     // Step 3: Normalize formatting tags for cross-platform compatibility
     result = normalizeFormattingTags(result);
     
@@ -258,16 +262,75 @@ function validate(html) {
 }
 
 /**
+ * Convert Odoo CSS class-based font sizes to inline styles
+ * so both Qt TextArea (RichTextPreview) and Squire (RichTextEditor)
+ * render them properly.
+ */
+function normalizeOdooClasses(html) {
+    if (!html) return "";
+    
+    var odooClassToSize = {
+        'display-1-fs': '96px',
+        'display-2-fs': '80px',
+        'display-3-fs': '64px',
+        'display-4-fs': '56px',
+        'h1-fs': '40px',
+        'h2-fs': '32px',
+        'h3-fs': '28px',
+        'h4-fs': '24px',
+        'h5-fs': '20px',
+        'h6-fs': '16px'
+    };
+
+    // Replace tag class attributes if they contain Odoo font-size classes
+    return html.replace(/<([a-z0-9]+)\b([^>]*)>/gi, function(match, tagName, attrs) {
+        var classMatch = attrs.match(/class\s*=\s*["']([^"']+)["']/i);
+        if (!classMatch) return match;
+        
+        var classNames = classMatch[1].split(/\s+/);
+        var matchedSize = null;
+        
+        for (var i = 0; i < classNames.length; i++) {
+            var className = classNames[i];
+            if (odooClassToSize.hasOwnProperty(className)) {
+                matchedSize = odooClassToSize[className];
+                break;
+            }
+        }
+        
+        if (!matchedSize) return match;
+        
+        // Match existing style attribute
+        var styleMatch = attrs.match(/style\s*=\s*["']([^"']*)["']/i);
+        if (styleMatch) {
+            var styleContent = styleMatch[1].trim();
+            // Check if font-size is already specified in the style (e.g. style="font-size: 32px")
+            if (!/font-size\s*:/i.test(styleContent)) {
+                if (styleContent && !styleContent.endsWith(';')) {
+                    styleContent += ';';
+                }
+                styleContent += ' font-size: ' + matchedSize + ';';
+                attrs = attrs.replace(/style\s*=\s*["']([^"']*)["']/i, 'style="' + styleContent + '"');
+            }
+        } else {
+            attrs += ' style="font-size: ' + matchedSize + ';"';
+        }
+        
+        return '<' + tagName + attrs + '>';
+    });
+}
+
+/**
  * Quick check if content needs sanitization
- * Only returns true for Qt-specific wrappers/styles that need removal
+ * Returns true for Qt-specific wrappers/styles, and Odoo font-size classes
  */
 function needsSanitization(html) {
     if (!html) return false;
     
-    // Only sanitize for Qt DOCTYPE wrapper or Qt-specific CSS properties
-    // Don't trigger for data attributes or margins (they don't break rendering)
+    // Sanitize for Qt DOCTYPE wrapper, Qt-specific CSS properties, or Odoo font-size classes
     return html.indexOf('<!DOCTYPE') !== -1 ||
-           html.indexOf('-qt-') !== -1;
+           html.indexOf('-qt-') !== -1 ||
+           /(?:display-[1-6]-fs|h[1-6]-fs)\b/.test(html);
 }
 
 /**


### PR DESCRIPTION
This pull request updates the font size handling in the rich text editor to use pixel (`px`) units instead of point (`pt`), expands the available font size options, and improves compatibility with Odoo-style font size CSS classes. It also standardizes the default font size to `13px` and ensures that Odoo font-size classes are converted to inline styles for consistent rendering across the editor and preview.

**Font size unit and default changes:**

* All font sizes are now handled in `px` units instead of `pt`, with the default font size changed from `12pt` to `13px` in `RichTextEditor.qml`, `HtmlEditorContainer.qml`, and `HtmlEditorToolbar.qml` (`[[1]](diffhunk://#diff-decd8e1c30a34b7bc0959b2c4486c5587048d9126c5e59c48e1b397a6b1006daL53-R54)`, `[[2]](diffhunk://#diff-867ec16fd1e3de6860bc52b6c946ce6855c0072fac9eea2786711d54cb6e73bdL51-R51)`, `[[3]](diffhunk://#diff-1e9056cf24e569881e4dca6fbca557c5d67c5dbc37cbd7828c8eab9f151d1205L30-R30)`).
* The font size selection list in `FontSizeDialog.qml` now uses `px` units, adds more size options, and wraps the list in a `Flickable` for better scrolling with long lists (`[[1]](diffhunk://#diff-ea1f97cd8d930b2036fcb9d43cc38e628ebe974e90ef13c5a13e0576aa5c9cfbR29-R61)`, `[[2]](diffhunk://#diff-ea1f97cd8d930b2036fcb9d43cc38e628ebe974e90ef13c5a13e0576aa5c9cfbR86)`).

**Odoo font size compatibility:**

* CSS classes for Odoo font sizes (e.g., `.display-1-fs`, `.h1-fs`) are defined in `editor.html` for visual consistency, and a new function `normalizeOdooClasses` in `html-sanitizer.js` converts these classes to inline `font-size` styles for better cross-platform rendering (`[[1]](diffhunk://#diff-47cb38df16facc96d9a6178b1e9b6d9f6fe095afb691bf71bc9a66d120f1b62fR169-R182)`, `[[2]](diffhunk://#diff-30f357e3e02bdffcad86ed35067072478f2fa526633aecac008917390db68d06R33-R36)`, `[[3]](diffhunk://#diff-30f357e3e02bdffcad86ed35067072478f2fa526633aecac008917390db68d06R264-R333)`).

**Font size formatting and sanitization:**

* The font size formatting function in `editor.html` is refactored to always return pixel values and to convert from `pt` to `px` when needed (`[[1]](diffhunk://#diff-47cb38df16facc96d9a6178b1e9b6d9f6fe095afb691bf71bc9a66d120f1b62fL319-R345)`, `[[2]](diffhunk://#diff-47cb38df16facc96d9a6178b1e9b6d9f6fe095afb691bf71bc9a66d120f1b62fL368-R387)`).
* The HTML sanitizer now detects Odoo font-size classes as needing sanitization and processes them to ensure consistent rendering (`[qml/components/richtext/js/html-sanitizer.jsR264-R333](diffhunk://#diff-30f357e3e02bdffcad86ed35067072478f2fa526633aecac008917390db68d06R264-R333)`).

**Other improvements:**

* The `zoomFactor` in `RichTextEditor.qml` is now set using `units.dp(1)` for improved scaling consistency (`[qml/components/richtext/RichTextEditor.qmlL581-R581](diffhunk://#diff-decd8e1c30a34b7bc0959b2c4486c5587048d9126c5e59c48e1b397a6b1006daL581-R581)`).