### PR TITLE
Shows actual creation error message when timesheet fails 

### DIFF
--- a/qml/features/timesheets/pages/Timesheet_Page.qml
+++ b/qml/features/timesheets/pages/Timesheet_Page.qml
@@ -98,7 +98,11 @@ Page {
                             "isReadOnly": false
                         });
                     } else {
-                        notifPopup.open("Error", result.message, "error");
+                        notifPopup.open(
+                            "Error", 
+                            result.error || "Failed to create timesheet.",
+                            "error"
+                        );
                     }
                 }
             }
@@ -369,7 +373,11 @@ Page {
                         "isReadOnly": false
                     });
                 } else {
-                    notifPopup.open("Error", result.message, "error");
+                    notifPopup.open(
+                        "Error",
+                        result.error || "Failed to create timesheet.",
+                        "error"
+                    );
                 }
             }
         }


### PR DESCRIPTION
## Summary

This improves the error reporting when creating a new timesheet.

## Problem

The backend returns errors using the 'error' property, but the QML page displays 'result.message', causing users to see an error instead of the actual failure reason.

## Changes

- Display 'result.error' in the notification popup.
- Add message if no specific error is available.

## Benefits

- Users receive actual error messages.
- Easier debugging.
- Improves user experience without changing timesheet creation logic.

<img width="781" height="430" alt="Screenshot 2026-08-07 182830" src="https://github.com/user-attachments/assets/30815fd7-bc94-435b-aee3-62897679ba16" />
